### PR TITLE
Fix correct IP reporting

### DIFF
--- a/Protected Endpoint.conf
+++ b/Protected Endpoint.conf
@@ -67,8 +67,9 @@ proxy_cache_bypass $cookie_session;
 proxy_no_cache $cookie_session;
 proxy_buffers 64 256k;
 
-set_real_ip_from 192.168.1.0/16;
-real_ip_header X-Forwarded-For;
+set_real_ip_from 172.18.0.0/16;
+set_real_ip_from 172.19.0.0/16;
+real_ip_header CF-Connecting-IP;
 real_ip_recursive on;
 
 }


### PR DESCRIPTION
Authelia was reporting only internal IP's (usually the reverse proxy). Changing these lines allows it to report the correct public IP connecting to the server.