### PR TITLE
Allow handover of email to app from FreeIPA

### DIFF
--- a/Protected Endpoint.conf
+++ b/Protected Endpoint.conf
@@ -36,9 +36,12 @@ proxy_pass $upstream_CONTAINERNAME;
 auth_request /authelia;
 auth_request_set $target_url https://$http_host$request_uri;
 auth_request_set $user $upstream_http_remote_user;
+auth_request_set $email $upstream_http_remote_email;
 auth_request_set $groups $upstream_http_remote_groups;
 proxy_set_header Remote-User $user;
+proxy_set_header Remote-Email $email;
 proxy_set_header Remote-Groups $groups;
+
 error_page 401 =302 https://auth.YOURDOMAIN.com/?rd=$target_url;
 
 client_body_buffer_size 128k;


### PR DESCRIPTION
Thanks @drazzilb08 for working to fix this issue with the email not being properly handed over to organizr. Also thanks to @causefx for adding the patch to organizr to allow mapping of the email from FreeIPA to organizr